### PR TITLE
Add id to notebooks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,10 +104,12 @@ ignore = [
     "E402", # Module level import not at top of file
     "E731", # Do not assign a lambda expression, use a def
     "E741", # Ambiguous variable name
+    "PLR2004", # magic-value-comparison
 ]
 fix = true
 unfixable = [
     "F401", # unused imports
+    "F841", # unused variables
 ]
 
 [tool.ruff.per-file-ignores]

--- a/src/clean_notebook/clean.py
+++ b/src/clean_notebook/clean.py
@@ -4,6 +4,8 @@ import json
 from pathlib import Path
 from typing import Any, AnyStr, Iterator
 
+__all__ = ("clean_notebook", "clean_single_notebook")
+
 
 def clean_notebook(
     paths: list[str | Path],

--- a/src/clean_notebook/clean.py
+++ b/src/clean_notebook/clean.py
@@ -75,7 +75,7 @@ def clean_single_notebook(
 
     if cleaned and not dryrun:
         with open(file, "w", encoding="utf8", newline=newline) as f:
-            json.dump(nb, f, indent=1, ensure_ascii=False)
+            json.dump(nb, f, indent=1, ensure_ascii=False, sort_keys=True)
             f.write(newline)  # empty line at the end of the file
         print(f"Cleaned notebook: {file}")
     elif cleaned:

--- a/tests/data/clean_colab.ipynb
+++ b/tests/data/clean_colab.ipynb
@@ -1,12 +1,4 @@
 {
- "nbformat": 4,
- "nbformat_minor": 0,
- "metadata": {
-  "language_info": {
-   "name": "python",
-   "pygments_lexer": "ipython3"
-  }
- },
  "cells": [
   {
    "cell_type": "code",
@@ -21,21 +13,29 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "print(\"saved from colab\")"
-   ],
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     ""
-   ],
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   ]
   }
- ]
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/tests/data/clean_id.ipynb
+++ b/tests/data/clean_id.ipynb
@@ -36,16 +36,8 @@
    "name": "python3"
   },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/tests/data/dirty_id.ipynb
+++ b/tests/data/dirty_id.ipynb
@@ -2,9 +2,10 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "3d183bd1-509f-4758-9f2d-db94b23c58f9",
-   "metadata": {},
+   "execution_count": 2,
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "a = 2"
@@ -12,7 +13,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "66cdc779-4931-4306-881a-4bf30cb0fdbb",
    "metadata": {},
    "source": [
     "Markdown"
@@ -20,7 +20,6 @@
   },
   {
    "cell_type": "raw",
-   "id": "5cbb8154-79ee-4290-953c-89a89b4276b7",
    "metadata": {},
    "source": [
     "Raw"
@@ -28,6 +27,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "name": "python",
    "pygments_lexer": "ipython3"

--- a/tests/data/with_id.ipynb
+++ b/tests/data/with_id.ipynb
@@ -1,0 +1,53 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "3d183bd1-509f-4758-9f2d-db94b23c58f9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "a = 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66cdc779-4931-4306-881a-4bf30cb0fdbb",
+   "metadata": {},
+   "source": [
+    "Markdown"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "5cbb8154-79ee-4290-953c-89a89b4276b7",
+   "metadata": {},
+   "source": [
+    "Raw"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_clean_notebook.py
+++ b/tests/test_clean_notebook.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import uuid
 from pathlib import Path
 from shutil import copy2, rmtree
@@ -93,7 +92,7 @@ def test_notebook_id(temp_path: Path, monkeypatch: MonkeyPatch) -> None:
     clean_single_notebook(dirty)
     clean_bytes = load_file(clean)
     dirty_bytes = load_file(dirty)
-    assert json.loads(clean_bytes) == json.loads(dirty_bytes)
+    assert clean_bytes == dirty_bytes
 
 
 def test_notebook_no_overwrite_ids(temp_path: Path) -> None:


### PR DESCRIPTION
Fixes #13 

Add cell ID if notebook version is greater or equal to 4.5 

Ref: https://jupyter.org/enhancement-proposals/62-cell-id/cell-id.html

Cells in Colab are not sorted, which this PR will now enforce. 